### PR TITLE
the rebuild workaround

### DIFF
--- a/templates/C++ Makefile/.vscode/tasks.json
+++ b/templates/C++ Makefile/.vscode/tasks.json
@@ -34,8 +34,8 @@
                 "isDefault": true
             },
             "command": "make",
-            "args": [
-                "rebuild"
+            "dependsOn": [
+                "Clean C/C++ Project"
             ],
             "problemMatcher": [
                 "$gcc"

--- a/templates/C++ Makefile/Makefile
+++ b/templates/C++ Makefile/Makefile
@@ -43,8 +43,6 @@ all:  $(TARGET)
 
 deps: $(CPP_DEPENDS)
 
-rebuild: clean all
-
 run: all
 	$(call PATH_CALL,$(TARGET))
 


### PR DESCRIPTION
since the rebuild did not work as expected this removes the rebuild target of make
and edits rebuild task in tasks.json to hanle rebuild
 On branch editC++MakefileTemplate
 Changes to be committed:
	modified:   templates/C++ Makefile/.vscode/tasks.json
	modified:   templates/C++ Makefile/Makefile